### PR TITLE
Hooks: sign transactions with connection

### DIFF
--- a/packages/react-sdk/src/hooks/session/useSessionKeyManager.ts
+++ b/packages/react-sdk/src/hooks/session/useSessionKeyManager.ts
@@ -14,8 +14,8 @@ export interface SessionWalletInterface {
   isLoading: boolean;
   error: string | null;
   sessionToken: string | null;
-  signTransaction: (<T extends Transaction>(transaction: T, connection?: Connection) => Promise<T>) | undefined;
-  signAllTransactions: (<T extends Transaction >(transactions: T[], connection?: Connection) => Promise<T[]>) | undefined;
+  signTransaction: (<T extends Transaction>(transaction: T, connection?: Connection, sendOptions?: SendTransactionOptions) => Promise<T>) | undefined;
+  signAllTransactions: (<T extends Transaction >(transactions: T[], connection?: Connection, sendOptions?: SendTransactionOptions) => Promise<T[]>) | undefined;
   signMessage: ((message: Uint8Array) => Promise<Uint8Array>) | undefined;
   sendTransaction: (<T extends Transaction>(transaction: T, connection?: Connection, options?: SendTransactionOptions) => Promise<string>) | undefined;
   signAndSendTransaction: (<T extends Transaction>(transactions: T | T[], connection?: Connection, options?: SendTransactionOptions) => Promise<string[]>) | undefined;
@@ -96,7 +96,7 @@ export function useSessionKeyManager(wallet: AnchorWallet, connection: Connectio
     }
   };
 
-  const signTransaction = async <T extends Transaction>(transaction: T, connection?: Connection): Promise<T> => {
+  const signTransaction = async <T extends Transaction>(transaction: T, connection?: Connection, sendOptions?: SendTransactionOptions): Promise<T> => {
     return withLoading(async () => {
       if (!keypairRef.current || !sessionTokenRef.current) {
         throw new Error('Cannot sign transaction - keypair or session token not loaded. Please create a session first.');
@@ -106,10 +106,12 @@ export function useSessionKeyManager(wallet: AnchorWallet, connection: Connectio
         connection = sessionConnection;
       }
 
-      const { blockhash } = await connection.getLatestBlockhash("finalized");
       const feePayer = keypairRef.current.publicKey;
 
-      transaction.recentBlockhash = transaction.recentBlockhash || blockhash;
+      transaction.recentBlockhash = transaction.recentBlockhash || (await connection.getLatestBlockhash({
+        commitment: sendOptions?.preflightCommitment,
+        minContextSlot: sendOptions?.minContextSlot,
+      })).blockhash;
       transaction.feePayer = transaction.feePayer || feePayer;
       transaction.sign(keypairRef.current);
 
@@ -117,9 +119,9 @@ export function useSessionKeyManager(wallet: AnchorWallet, connection: Connectio
     });
   };
 
-  const signAllTransactions = async <T extends Transaction>(transactions: T[], connection?: Connection): Promise<T[]> => {
+  const signAllTransactions = async <T extends Transaction>(transactions: T[], connection?: Connection, sendOptions?: SendTransactionOptions): Promise<T[]> => {
     return withLoading(async () => {
-      return Promise.all(transactions.map((transaction) => signTransaction(transaction, connection)));
+      return Promise.all(transactions.map((transaction) => signTransaction(transaction, connection, sendOptions)));
     });
   };
 
@@ -173,7 +175,7 @@ export function useSessionKeyManager(wallet: AnchorWallet, connection: Connectio
         transaction.partialSign(...signers);
       }
 
-      transaction = await signTransaction(transaction);
+      transaction = await signTransaction(transaction, connection);
 
       const txid = await connection.sendRawTransaction(
         transaction.serialize(),


### PR DESCRIPTION
For signing transactions, it uses the default provider set during the creation of session key manager. In situations where we want to send the transaction to magicblock but the session key manager is initialized with a different connection ( so that we can create the session ), then during the signing of the transaction it would use the default one. The problem with this is that the default connection ( devnet/mainnet ) wouldnt be as fast as the magicblock endpoint which can cause delays in submitting the transaction ( mainly because it fetches the blockhash from the default connection ). Allowing passing of the connection to signTransaction would mitigate this issue.

Also fetch the blockhash in `signTransaction` only if it doesnt exist.